### PR TITLE
Fix Vercel runtime specification

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/index.js": {
-      "runtime": "nodejs18.x"
+      "runtime": "@vercel/node@2.16.1"
     }
   }
 }


### PR DESCRIPTION
## Summary
- set the API function runtime to an explicit `@vercel/node` version so that Vercel accepts the configuration

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ceda03e9148325861d19f367d5843e