### PR TITLE
Widen Vercel function runtime mapping

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
-    "api/index.js": {
-      "runtime": "nodejs18.x"
+    "api/**/*.js": {
+      "runtime": "@vercel/node@2.15.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- configure the Vercel functions glob so every API handler uses the pinned @vercel/node@2.15.0 runtime

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ceda03e9148325861d19f367d5843e