### PR TITLE
fix: set vercel runtime to 2.15.0

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
-    "api/index.js": {
-      "runtime": "@vercel/node@2.16.1"
+    "api/**/*.js": {
+      "runtime": "@vercel/node@2.15.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- update Vercel configuration to apply the `@vercel/node@2.15.0` runtime to all API function entry points

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee10fb4dc8325b738fefc91627c75