### PR TITLE
chore: set vercel node to 18

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,13 @@
     "api/**/*.js": {
       "runtime": "@vercel/node@2.15.0"
     }
+  },
+  "build": {
+    "env": {
+      "NODE_VERSION": "18.x"
+    }
+  },
+  "env": {
+    "NODE_VERSION": "18.x"
   }
 }


### PR DESCRIPTION
## Summary
- set the Vercel build and runtime environments to use Node 18.x

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cef448a91c83258fd673cca285eebe