### PR TITLE
test: align medusa package resolvers

### DIFF
--- a/define_jest_config.js
+++ b/define_jest_config.js
@@ -1,4 +1,48 @@
-module.exports = function defineJestConfig(config) {
+const path = require("path")
+
+const MEDUSA_RESOLVER = path.resolve(__dirname, "jest.medusa-resolver.js")
+
+const getCallerDir = () => {
+  const originalPrepareStackTrace = Error.prepareStackTrace
+  try {
+    Error.prepareStackTrace = (_, stack) => stack
+    const { stack } = new Error()
+
+    if (Array.isArray(stack)) {
+      for (const callsite of stack) {
+        const fileName = callsite.getFileName?.()
+
+        if (!fileName || fileName === __filename) {
+          continue
+        }
+
+        return path.dirname(fileName)
+      }
+    }
+  } catch (err) {
+    // Fall back to the current working directory if we cannot determine the caller.
+  } finally {
+    Error.prepareStackTrace = originalPrepareStackTrace
+  }
+
+  return process.cwd()
+}
+
+module.exports = function defineJestConfig(config = {}) {
+  const callerDir = getCallerDir()
+  const {
+    moduleNameMapper: userModuleNameMapper = {},
+    rootDir: userRootDir,
+    resolver: userResolver,
+    ...restConfig
+  } = config
+
+  const rootDir = userRootDir ?? callerDir
+  const moduleNameMapper = {
+    ...userModuleNameMapper,
+  }
+  const resolver = userResolver ?? MEDUSA_RESOLVER
+
   return {
     transform: {
       "^.+\\.[jt]s$": [
@@ -22,9 +66,12 @@ module.exports = function defineJestConfig(config) {
     },
     modulePathIgnorePatterns: [`dist/`],
     testPathIgnorePatterns: [`dist/`, `node_modules/`],
-    transformIgnorePatterns: ["node_modules/"],
+    transformIgnorePatterns: ["node_modules/(?!@medusajs/)"],
     testEnvironment: `node`,
     moduleFileExtensions: [`js`, `ts`],
-    ...config,
+    moduleNameMapper,
+    resolver,
+    rootDir,
+    ...restConfig,
   }
 }

--- a/jest.medusa-resolver.js
+++ b/jest.medusa-resolver.js
@@ -1,0 +1,114 @@
+const fs = require("fs")
+const path = require("path")
+
+const DEFAULT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json"]
+const ROOT_NODE_MODULES = path.resolve(__dirname, "node_modules")
+
+const debug = (...args) => {
+  if (process.env.JEST_MEDUSA_DEBUG) {
+    // eslint-disable-next-line no-console
+    console.error("[medusa-resolver]", ...args)
+  }
+}
+
+const normalizeSubPath = (subPath) => {
+  if (!subPath) {
+    return ""
+  }
+
+  if (subPath.startsWith("dist/")) {
+    return subPath.slice("dist/".length)
+  }
+
+  return subPath
+}
+
+const resolveWithExtensions = (basePath, extensions) => {
+  if (fs.existsSync(basePath)) {
+    const stats = fs.statSync(basePath)
+
+    if (stats.isFile()) {
+      return basePath
+    }
+
+    if (stats.isDirectory()) {
+      for (const ext of extensions) {
+        const candidate = path.join(basePath, `index${ext}`)
+
+        if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+          return candidate
+        }
+      }
+    }
+  }
+
+  for (const ext of extensions) {
+    const candidate = `${basePath}${ext}`
+
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+module.exports = (request, options) => {
+  if (!request.startsWith("@medusajs/")) {
+    return options.defaultResolver(request, options)
+  }
+
+  const [scope, pkg, ...rest] = request.split("/")
+
+  if (!scope || !pkg) {
+    return options.defaultResolver(request, options)
+  }
+
+  const packageName = `${scope}/${pkg}`
+
+  try {
+    let pkgDir = path.join(ROOT_NODE_MODULES, packageName)
+
+    if (!fs.existsSync(pkgDir)) {
+      const pkgJsonPath = options.defaultResolver(`${packageName}/package.json`, {
+        ...options,
+        packageFilter: undefined,
+      })
+
+      pkgDir = path.dirname(pkgJsonPath)
+    }
+    const srcDir = path.join(pkgDir, "src")
+    const extensions = Array.from(
+      new Set([...(options.extensions || []), ...DEFAULT_EXTENSIONS])
+    )
+
+    const subPath = normalizeSubPath(rest.join("/"))
+    const targetBase = subPath ? path.join(srcDir, subPath) : srcDir
+    debug(`Resolving ${request}`, {
+      packageName,
+      subPath,
+      targetBase,
+    })
+    const resolvedPath = resolveWithExtensions(targetBase, extensions)
+
+    if (resolvedPath) {
+      debug(`Resolved ${request} to ${resolvedPath}`)
+      return resolvedPath
+    }
+    if (packageName === "@medusajs/medusa" && subPath) {
+      const moduleBase = path.join(srcDir, "modules", subPath)
+      const modulePath = resolveWithExtensions(moduleBase, extensions)
+
+      if (modulePath) {
+        debug(`Resolved ${request} to ${modulePath} via modules fallback`)
+        return modulePath
+      }
+    }
+    debug(`Falling back to default resolver for ${request}`)
+  } catch (err) {
+    // Ignore resolution errors and fall back to Jest's default resolver.
+    debug(`Error resolving ${request}:`, err)
+  }
+
+  return options.defaultResolver(request, options)
+}

--- a/packages/admin/dashboard/vite.config.mts
+++ b/packages/admin/dashboard/vite.config.mts
@@ -1,7 +1,14 @@
-import inject from "@medusajs/admin-vite-plugin"
+import { resolve, sep } from "path"
+
+import inject from "../admin-vite-plugin/src/index"
 import react from "@vitejs/plugin-react"
 import { defineConfig, loadEnv } from "vite"
 import inspect from "vite-plugin-inspect"
+
+const toPosix = (value: string) => value.split(sep).join("/")
+const medusaAliasBase = toPosix(
+  resolve(__dirname, "../../..", "node_modules", "@medusajs")
+)
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -26,6 +33,18 @@ export default defineConfig(({ mode }) => {
         sources,
       }),
     ],
+    resolve: {
+      alias: [
+        {
+          find: /^@medusajs\/([^/]+)$/, 
+          replacement: `${medusaAliasBase}/$1/src/index.ts`,
+        },
+        {
+          find: /^@medusajs\/([^/]+)\/(.*)$/, 
+          replacement: `${medusaAliasBase}/$1/src/$2`,
+        },
+      ],
+    },
     define: {
       __BASE__: JSON.stringify(BASE),
       __BACKEND_URL__: JSON.stringify(BACKEND_URL),

--- a/packages/admin/dashboard/vitest.config.ts
+++ b/packages/admin/dashboard/vitest.config.ts
@@ -1,5 +1,6 @@
 import { resolve, sep } from "path"
 import { defineConfig } from "vitest/config"
+import react from "@vitejs/plugin-react"
 
 const toPosix = (value: string) => value.split(sep).join("/")
 const medusaAliasBase = toPosix(
@@ -7,10 +8,11 @@ const medusaAliasBase = toPosix(
 )
 
 export default defineConfig({
+  plugins: [react()],
   resolve: {
     alias: [
       {
-        find: /^@medusajs\/([^/]+)$/, 
+        find: /^@medusajs\/([^/]+)$/,
         replacement: `${medusaAliasBase}/$1/src/index.ts`,
       },
       {
@@ -20,8 +22,6 @@ export default defineConfig({
     ],
   },
   test: {
-    globals: true,
-    environment: "node",
-    include: ["**/*.spec.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+    environment: "jsdom",
   },
 })

--- a/packages/design-system/ui/vite.config.ts
+++ b/packages/design-system/ui/vite.config.ts
@@ -1,20 +1,35 @@
 /// <reference types="vitest" />
 /// <reference types="vite/client" />
 
+import { resolve, sep } from "path"
+
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
+
+const toPosix = (value: string) => value.split(sep).join("/")
+const medusaAliasBase = toPosix(
+  resolve(__dirname, "../../..", "node_modules", "@medusajs")
+)
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@/blocks": "/src/blocks",
-      "@/components": "/src/components",
-      "@/providers": "/src/providers",
-      "@/hooks": "/src/hooks",
-      "@/utils": "/src/utils",
-      "@/types": "/src/types",
-    },
+    alias: [
+      { find: "@/blocks", replacement: "/src/blocks" },
+      { find: "@/components", replacement: "/src/components" },
+      { find: "@/providers", replacement: "/src/providers" },
+      { find: "@/hooks", replacement: "/src/hooks" },
+      { find: "@/utils", replacement: "/src/utils" },
+      { find: "@/types", replacement: "/src/types" },
+      {
+        find: /^@medusajs\/([^/]+)$/,
+        replacement: `${medusaAliasBase}/$1/src/index.ts`,
+      },
+      {
+        find: /^@medusajs\/([^/]+)\/(.*)$/,
+        replacement: `${medusaAliasBase}/$1/src/$2`,
+      },
+    ],
   },
   test: {
     setupFiles: "./setup-test.ts",

--- a/packages/medusa/jest.config.js
+++ b/packages/medusa/jest.config.js
@@ -1,17 +1,6 @@
-module.exports = {
-  //moduleNameMapper: {
-  //  "^highlight.js$": `<rootDir>/node_modules/highlight.js/lib/index.js`,
-  //},
-  //snapshotSerializers: [`jest-serializer-path`],
-  // collectCoverageFrom: coverageDirs,
-  //reporters: process.env.CI
-  //  ? [[`jest-silent-reporter`, { useDots: true }]].concat(
-  //      useCoverage ? `jest-junit` : []
-  //    )
-  //  : [`default`].concat(useCoverage ? `jest-junit` : []),
-  transform: { "^.+\\.[jt]s?$": "@swc/jest" },
+const defineJestConfig = require("../../define_jest_config")
+
+module.exports = defineJestConfig({
   modulePathIgnorePatterns: ["__fixtures__", "node_modules", "dist"],
-  testEnvironment: `node`,
-  moduleFileExtensions: [`js`, `ts`],
   setupFilesAfterEnv: ["<rootDir>/setupTests.js"],
-}
+})


### PR DESCRIPTION
## Summary
- add the shared `jest.medusa-resolver` integration so jest-based packages resolve `@medusajs/*` modules from `src/`
- align dashboard and design system Vite/Vitest configs with regex aliases that target package sources
- update the admin Vite plugin Vitest config to use the same resolver aliases for `@medusajs/*`

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68cef9e5597483258c1fa1319d059115